### PR TITLE
Fix managed component react warning

### DIFF
--- a/src/cljs/re_datagrid/views.cljs
+++ b/src/cljs/re_datagrid/views.cljs
@@ -42,7 +42,7 @@
          [:div.checkbox
           [:label
            [:input {:type      :checkbox
-                    :checked   (if @record-selected? "checked" nil)
+                    :checked   (if @record-selected? true false)
                     :on-change #(rf/dispatch [:datagrid/toggle-checkbox id record])}]
            [:i.input-helper]]]]))))
 
@@ -205,7 +205,7 @@
       [:div.checkbox
        [:label
         [:input {:type      :checkbox
-                 :checked   @checked?
+                 :checked   (if @checked? true false)
                  :on-change #(rf/dispatch [:datagrid/toggle-mass-select id @visible-records])}]
         [:i.input-helper]]])))
 

--- a/src/cljs/re_datagrid_demo/views.cljs
+++ b/src/cljs/re_datagrid_demo/views.cljs
@@ -15,6 +15,7 @@
    :header-filters    true
    :can-sort          true
    :can-reorder       true
+   :checkbox-select   true
    :loading-subscription [:my-loading]
    :reorder-dispatch  [:reorder]
    :create-dispatch   [:create]


### PR DESCRIPTION
Don't pass "checked" or nil to :checked, make sure it is true or false.